### PR TITLE
Don't use ALLOC_PRIM, as it might trigger GC

### DIFF
--- a/cbits/dup-prim.cmm
+++ b/cbits/dup-prim.cmm
@@ -44,7 +44,7 @@ dupClosure(P_ clos)
         (len) = foreign "C" closure_sizeW(clos "ptr");
         bytes = WDS(len);
 
-        ALLOC_PRIM (bytes);
+        ALLOC_PRIM_P(bytes, dupClosure, clos);
 
         W_ copy;
         copy = Hp - bytes + WDS(1);


### PR DESCRIPTION
If that happened, the closure could have moved, and we'd end up copying garbage. Unfortunately, this does not fix the CAF problem.