### PR TITLE
Changes for dupIO conduit blog post

### DIFF
--- a/dupIO.cabal
+++ b/dupIO.cabal
@@ -117,8 +117,14 @@ test-suite test-dupIO
 
   if flag(use-debug-RTS)
     ghc-options:
+      -threaded
+      -rtsopts
       -with-rtsopts "-T -DS"
       -debug
+    if impl(ghc >= 9.2.0)
+      ghc-options:
+        -fdistinct-constructor-tables
+        -finfo-table-map
 
 --------------------------------------------------------------------------------
 -- Demos

--- a/test/Test/DupIO/Conduit/Closed.hs
+++ b/test/Test/DupIO/Conduit/Closed.hs
@@ -17,13 +17,13 @@ import Test.Util.TestSetup
 
 tests :: TestTree
 tests = testGroup "Test.DupIO.Conduit.Closed" [
-      testLocalOOM "withoutDupIO.OOM" test_withoutDupIO
-    , testCaseInfo "innerDupIO.OK"    test_innerDupIO
+      testLocalOOM "sourceWithoutDupIO.OOM" test_sourceWithoutDupIO
+    , testCaseInfo "sourceInnerDupIO.OK"    test_sourceInnerDupIO
 --    , testCaseInfo "OK.cafWithDupIO"  test_cafWithDupIO
     ]
 
-test_withoutDupIO :: IO String
-test_withoutDupIO = \w0 ->
+test_sourceWithoutDupIO :: IO String
+test_sourceWithoutDupIO = \w0 ->
     let !(# w1, ref #) = unwrapIO (newIORef 0) w0
         c = addFrom ref limit
         !(# w2, () #) = retry (runConduit c <* checkMem (1 * mb)) w1
@@ -32,8 +32,8 @@ test_withoutDupIO = \w0 ->
     limit :: Int
     limit = 100_000
 
-test_innerDupIO :: IO String
-test_innerDupIO = \w0 ->
+test_sourceInnerDupIO :: IO String
+test_sourceInnerDupIO = \w0 ->
     let !(# w1, ref #) = unwrapIO (newIORef 0) w0
         c = addFrom ref limit
         !(# w2, () #) = retry (innerDupIO c <* checkMem (1 * mb)) w1

--- a/test/Test/DupIO/Conduit/Sink.hs
+++ b/test/Test/DupIO/Conduit/Sink.hs
@@ -13,23 +13,23 @@ import Test.Util.TestSetup
 
 tests :: TestTree
 tests = testGroup "Test.DupIO.Conduit.Sink" [
-      testLocalOOM "withoutDupIO.OOM"                 test_withoutDupIO
-    , testCaseInfo "innerDupIO.OK"                    test_innerDupIO
-    , testCaseInfo "innerDupIO_partiallyEvaluated.OK" test_innerDupIO_partiallyEvaluated
+      testLocalOOM "sinkWithoutDupIO.OOM"                 test_sinkWithoutDupIO
+    , testCaseInfo "sinkInnerDupIO.OK"                    test_sinkInnerDupIO
+    , testCaseInfo "sinkInnerDupIO_partiallyEvaluated.OK" test_sinkInnerDupIO_partiallyEvaluated
 --    , testCaseInfo "OK.cafWithDupIO"  test_cafWithDupIO
     ]
 
-test_withoutDupIO :: IO String
-test_withoutDupIO = \w0 ->
+test_sinkWithoutDupIO :: IO String
+test_sinkWithoutDupIO = \w0 ->
     let c                 = countChars 0
-        !(# w1, _count #) = retry (runConduit limit 'a' c <* checkMem (1 * mb)) w0
+        !(# w1, _count #) = retry (runSinkConduit limit 'a' c <* checkMem (1 * mb)) w0
     in (# w1, "succeeded with 1MB memory limit" #)
   where
     limit :: Int
     limit = 250_000
 
-test_innerDupIO :: IO String
-test_innerDupIO = \w0 ->
+test_sinkInnerDupIO :: IO String
+test_sinkInnerDupIO = \w0 ->
     let c                 = countChars 0
         !(# w1, _count #) = retry (innerDupIO limit 'a' c <* checkMem (1 * mb)) w0
     in (# w1, "succeeded with 1MB memory limit" #)
@@ -37,8 +37,8 @@ test_innerDupIO = \w0 ->
     limit :: Int
     limit = 250_000
 
-test_innerDupIO_partiallyEvaluated :: IO String
-test_innerDupIO_partiallyEvaluated = \w0 ->
+test_sinkInnerDupIO_partiallyEvaluated :: IO String
+test_sinkInnerDupIO_partiallyEvaluated = \w0 ->
     let c                 = countChars 0
         !(# w1, c'     #) = evaluate c                                           w0
         !(# w2, _count #) = retry (innerDupIO limit 'a' c' <* checkMem (1 * mb)) w1
@@ -47,8 +47,8 @@ test_innerDupIO_partiallyEvaluated = \w0 ->
     limit :: Int
     limit = 250_000
 
-_test_cafWithDupIO :: IO String
-_test_cafWithDupIO = \w0 ->
+_test_sinkCafWithDupIO :: IO String
+_test_sinkCafWithDupIO = \w0 ->
     let !(# w1, _count #) = retry (innerDupIO limit 'a' caf <* checkMem (1 * mb)) w0
     in (# w1, "succeeded with 1MB memory limit" #)
   where
@@ -65,9 +65,9 @@ _test_cafWithDupIO = \w0 ->
 caf :: Sink (Maybe Char) Int
 caf = countChars 0
 
-{-# NOINLINE runConduit #-}
-runConduit :: Int -> Char -> Sink (Maybe Char) Int -> IO Int
-runConduit limit ch =
+{-# NOINLINE runSinkConduit #-}
+runSinkConduit :: Int -> Char -> Sink (Maybe Char) Int -> IO Int
+runSinkConduit limit ch =
     go limit
   where
     go :: Int -> Sink (Maybe Char) Int -> IO Int

--- a/test/Test/DupIO/Conduit/Source/Bidirectional.hs
+++ b/test/Test/DupIO/Conduit/Source/Bidirectional.hs
@@ -13,11 +13,11 @@ import Test.Util.TestSetup
 
 tests :: TestTree
 tests = testGroup "Test.DupIO.Conduit.Source.Bidirectional" [
-      testCaseInfo "innerDupIO_partiallyEvaluated.OK"  test_innerDupIO_partiallyEvaluated
+      testCaseInfo "sourceInnerDupIO_partiallyEvaluated.OK"  test_sourceInnerDupIO_partiallyEvaluated
     ]
 
-test_innerDupIO_partiallyEvaluated :: IO String
-test_innerDupIO_partiallyEvaluated = \w0 ->
+test_sourceInnerDupIO_partiallyEvaluated :: IO String
+test_sourceInnerDupIO_partiallyEvaluated = \w0 ->
     let c               = yieldFrom limit
         !(# w1, c'   #) = evaluate c                                 w0
         !(# w2, _sum #) = retry (innerDupIO c' <* checkMem (1 * mb)) w1

--- a/test/Test/DupIO/Conduit/Source/IO.hs
+++ b/test/Test/DupIO/Conduit/Source/IO.hs
@@ -18,14 +18,14 @@ import Test.Util.Conduit.Source.IO
 
 tests :: TestTree
 tests = testGroup "Test.DupIO.Conduit.Source.IO" [
-      testCaseInfo "withoutDUPIO_variant1.OK"  test_withoutDupIO_variant1
-    , testLocalOOM "withoutDUPIO_variant2.OOM" test_withoutDupIO_variant2
-    , testCaseInfo "withoutDUPIO_variant3.OK"  test_withoutDupIO_variant3
-    , testCaseInfo "innerDupIO.variant2_OK"    test_innerDupIO_variant2
+      testCaseInfo "sourceWithoutDUPIO_variant1.OK"  test_sourceWithoutDupIO_variant1
+    , testLocalOOM "sourceWithoutDUPIO_variant2.OOM" test_sourceWithoutDupIO_variant2
+    , testCaseInfo "sourceWithoutDUPIO_variant3.OK"  test_sourceWithoutDupIO_variant3
+    , testCaseInfo "sourceInnerDupIO.variant2_OK"          test_sourceInnerDupIO_variant2
     ]
 
-test_withoutDupIO_variant1 :: IO String
-test_withoutDupIO_variant1 = \w0 ->
+test_sourceWithoutDupIO_variant1 :: IO String
+test_sourceWithoutDupIO_variant1 = \w0 ->
     let c = yieldFrom1 limit
         !(# w1, _sum #) = retry (runConduit c <* checkMem (1 * mb)) w0
     in (# w1, "succeeded with 1MB memory limit" #)
@@ -33,8 +33,8 @@ test_withoutDupIO_variant1 = \w0 ->
     limit :: Int
     limit = 250_000
 
-test_withoutDupIO_variant2 :: IO String
-test_withoutDupIO_variant2 = \w0 ->
+test_sourceWithoutDupIO_variant2 :: IO String
+test_sourceWithoutDupIO_variant2 = \w0 ->
     let c = yieldFrom2 limit
         !(# w1, _sum #) = retry (runConduit c <* checkMem (1 * mb)) w0
     in (# w1, "succeeded with 1MB memory limit" #)
@@ -42,8 +42,8 @@ test_withoutDupIO_variant2 = \w0 ->
     limit :: Int
     limit = 250_000
 
-test_withoutDupIO_variant3 :: IO String
-test_withoutDupIO_variant3 = \w0 ->
+test_sourceWithoutDupIO_variant3 :: IO String
+test_sourceWithoutDupIO_variant3 = \w0 ->
     let c = yieldFrom3 limit
         !(# w1, _sum #) = retry (runConduit c <* checkMem (1 * mb)) w0
     in (# w1, "succeeded with 1MB memory limit" #)
@@ -51,8 +51,8 @@ test_withoutDupIO_variant3 = \w0 ->
     limit :: Int
     limit = 250_000
 
-test_innerDupIO_variant2 :: IO String
-test_innerDupIO_variant2 = \w0 ->
+test_sourceInnerDupIO_variant2 :: IO String
+test_sourceInnerDupIO_variant2 = \w0 ->
     let c = yieldFrom2 limit
         !(# w1, _sum #) = retry (innerDupIO c <* checkMem (1 * mb)) w0
     in (# w1, "succeeded with 1MB memory limit" #)


### PR DESCRIPTION
These changes made some things clearer in the dupIO conduit blog post. Bulk of the changes are renaming test functions to indicate whether they are testing source or sink conduits