### PR TITLE
Don't copy static closures

### DIFF
--- a/cbits/dup-prim.cmm
+++ b/cbits/dup-prim.cmm
@@ -11,7 +11,7 @@ dupClosure(P_ clos)
 
     // Check if we can/should copy this closure
     switch [0 .. N_CLOSURE_TYPES] type {
-        case FUN, FUN_1_0, FUN_0_1, FUN_1_1, FUN_2_0, FUN_0_2, FUN_STATIC: {
+        case FUN, FUN_1_0, FUN_0_1, FUN_1_1, FUN_2_0, FUN_0_2: {
             goto type_ok;
         }
 
@@ -25,10 +25,11 @@ dupClosure(P_ clos)
         }
 
         // Thunks are good
-        case THUNK, THUNK_1_0, THUNK_0_1, THUNK_2_0, THUNK_1_1, THUNK_0_2, THUNK_STATIC, THUNK_SELECTOR, AP, PAP: {
+        case THUNK, THUNK_1_0, THUNK_0_1, THUNK_2_0, THUNK_1_1, THUNK_0_2, THUNK_SELECTOR, AP, PAP: {
             goto type_ok;
         }
 
+        // FUN_STATIC, THUNK_STATIC fall through to this case because of #9
         default: {
             goto type_not_ok;
         }

--- a/test/Test/DupIO/Conduit/Closed.hs
+++ b/test/Test/DupIO/Conduit/Closed.hs
@@ -19,7 +19,7 @@ tests :: TestTree
 tests = testGroup "Test.DupIO.Conduit.Closed" [
       testLocalOOM "withoutDupIO.OOM" test_withoutDupIO
     , testCaseInfo "innerDupIO.OK"    test_innerDupIO
---    , testCaseInfo "OK.cafWithDupIO"  test_cafWithDupIO
+    , testCaseInfo "OK.cafWithDupIO"  test_cafWithDupIO
     ]
 
 test_withoutDupIO :: IO String
@@ -42,8 +42,8 @@ test_innerDupIO = \w0 ->
     limit :: Int
     limit = 100_000
 
-_test_cafWithDupIO :: IO String
-_test_cafWithDupIO = \w0 ->
+test_cafWithDupIO :: IO String
+test_cafWithDupIO = \w0 ->
     let !(# w1, () #) = retry (innerDupIO caf <* checkMem (1 * mb)) w0
     in (# w1, "succeeded with 1MB memory limit" #)
 

--- a/test/Test/DupIO/Conduit/Sink.hs
+++ b/test/Test/DupIO/Conduit/Sink.hs
@@ -16,7 +16,7 @@ tests = testGroup "Test.DupIO.Conduit.Sink" [
       testLocalOOM "withoutDupIO.OOM"                 test_withoutDupIO
     , testCaseInfo "innerDupIO.OK"                    test_innerDupIO
     , testCaseInfo "innerDupIO_partiallyEvaluated.OK" test_innerDupIO_partiallyEvaluated
---    , testCaseInfo "OK.cafWithDupIO"  test_cafWithDupIO
+    , testCaseInfo "OK.cafWithDupIO"  test_cafWithDupIO
     ]
 
 test_withoutDupIO :: IO String
@@ -47,8 +47,8 @@ test_innerDupIO_partiallyEvaluated = \w0 ->
     limit :: Int
     limit = 250_000
 
-_test_cafWithDupIO :: IO String
-_test_cafWithDupIO = \w0 ->
+test_cafWithDupIO :: IO String
+test_cafWithDupIO = \w0 ->
     let !(# w1, _count #) = retry (innerDupIO limit 'a' caf <* checkMem (1 * mb)) w0
     in (# w1, "succeeded with 1MB memory limit" #)
   where

--- a/test/Test/DupIO/Conduit/Source.hs
+++ b/test/Test/DupIO/Conduit/Source.hs
@@ -26,7 +26,7 @@ tests = testGroup "Test.DupIO.Conduit.Source" [
     , testLocalOOM "outerDupIO_partiallyEvaluated.OOM" test_outerDupIO_partiallyEvaluated
     , testCaseInfo "innerDupIO.OK"                     test_innerDupIO
     , testCaseInfo "innerDupIO_partiallyEvaluated.OK"  test_innerDupIO_partiallyEvaluated
---    , testCaseInfo "OK.cafWithDupIO"  test_cafWithDupIO
+    , testCaseInfo "OK.cafWithDupIO"  test_cafWithDupIO
     ]
 
 test_withoutDupIO :: IO String
@@ -76,8 +76,8 @@ test_innerDupIO_partiallyEvaluated = \w0 ->
     limit :: Int
     limit = 250_000
 
-_test_cafWithDupIO :: IO String
-_test_cafWithDupIO = \w0 ->
+test_cafWithDupIO :: IO String
+test_cafWithDupIO = \w0 ->
     let !(# w1, _sum #) = retry (outerDupIO caf <* checkMem (1 * mb)) w0
     in (# w1, "succeeded with 1MB memory limit" #)
 


### PR DESCRIPTION
This is a workaround for the crash observed in #9. Not copying static closures should avoid crashing, at the cost of some test failures where `dupIO` is no longer effective.